### PR TITLE
RG-4 Deploy. Фикс APP_ENV=prod для composer install на CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,11 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     environment: production
+    env:
+      # .env по умолчанию содержит APP_ENV=dev — без явного прод-окружения здесь
+      # автоскрипт `cache:clear` после composer install --no-dev пытается
+      # загрузить DebugBundle, которого нет среди прод-зависимостей, и падает.
+      APP_ENV: prod
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Проблема

Первый прод-деплой упал на автоскрипте `cache:clear` после `composer install --no-dev`:

```
Attempted to load class "DebugBundle" from namespace "Symfony\Bundle\DebugBundle"
```

## Причина

`.env` по умолчанию содержит `APP_ENV=dev`. `DebugBundle` в `config/bundles.php`
зарегистрирован только для `dev`. При `composer install --no-dev` пакет
`symfony/debug-bundle` не ставится (он в `require-dev`), но Flex-автоскрипт
`cache:clear`, вызванный без явного окружения, всё равно пытается загрузить
кернел в `dev` — класса нет, падение.

## Исправление

Задал `APP_ENV: prod` на уровне джоба `deploy` в `.github/workflows/ci.yml`,
до шага `composer install`.

## Проверено

В отдельном `git worktree` (чтобы не портить dev-зависимости в рабочей копии):

```
APP_ENV=prod composer install --no-interaction --no-progress --prefer-dist --no-dev --optimize-autoloader
...
Executing script cache:clear [OK]
Executing script assets:install public [OK]
```